### PR TITLE
Update Speak_with_AquesTalk.ino

### DIFF
--- a/examples/Advanced/Speak_with_AquesTalk/Speak_with_AquesTalk.ino
+++ b/examples/Advanced/Speak_with_AquesTalk/Speak_with_AquesTalk.ino
@@ -68,7 +68,7 @@ void setup(void)
 
   M5.begin(cfg);
 
-  xTaskCreate(talk_task, "talk_task", 2048, nullptr, 1, &task_handle);
+  xTaskCreateUniversal(talk_task, "talk_task", 2048, nullptr, 1, &task_handle, APP_CPU_NUM);
 /*
   /// Increasing the sample_rate will improve the sound quality instead of increasing the CPU load.
   auto spk_cfg = M5.Speaker.config();
@@ -114,7 +114,7 @@ extern "C" {
 
   void app_main()
   {
-    xTaskCreatePinnedToCore(loopTask, "loopTask", 8192, NULL, 1, NULL, 1);
+    xTaskCreateUniversal(loopTask, "loopTask", 8192, NULL, 1, NULL, APP_CPU_NUM);
   }
 }
 #endif


### PR DESCRIPTION
xTaskCreate function is not for dual core esp32.
xTaskCreateUniversal has upward compatibility of xTaskCreate, it can set a task on each core like xTaskCreatePinnedToCore.

When there is some network function, the task runs on PRO_CPU_NUM(=0).
In this situation, it's better for the other function like AquesTalk to be set on APP_CPU_NUM(=1).

This change improves sound quality in my project that uses wifi udp and AquesTalk in multi tasks.